### PR TITLE
A redirect will be created if a player with the same ID is found

### DIFF
--- a/cron_new_players.py
+++ b/cron_new_players.py
@@ -24,7 +24,7 @@ result = site.cargo_client.query(
     tables='TournamentResults=TR,TournamentResults__RosterLinks=RL,_pageData=PD,Tournaments=T',
     join_on='TR._ID=RL._rowID,RL._value=PD._pageName,TR.OverviewPage=T._pageName',
     where='PD._pageName IS NULL AND RL._value IS NOT NULL AND TR.PRPoints > "0"',
-    fields='RL._value=name,T.Region=res, TR.RosterLinks__full=RosterLinks, TR.RosterIds__full=RosterIds,TR.OverviewPage=overview',
+    fields='TR._pageName=tournament,RL._value=name,T.Region=res, TR.RosterLinks__full=RosterLinks, TR.RosterIds__full=RosterIds',
     group_by='RL._value',
     limit='max'
 )
@@ -89,7 +89,7 @@ for item in result:
             # if so then move it to the new name (dw about fixing double redirects, whatever)
             if original_page_name is not None:
                 site.client.pages[original_page_name].move(name)
-                site.client.pages["Data:{}".format(item['overview'])].touch()
+                site.client.pages['tournament'].touch()
                 site.client.pages[original_page_name].touch()
                 this_wikitext = mwparserfromhell.parse(site.client.pages[name].text())
                 for template in this_wikitext.filter_templates():


### PR DESCRIPTION
* Players with quoutes (&quot;) in their name will be skipped
* A redirect will be created for players whose ID is known.
   * Added a new summary for this case
   * Added "TR._pageName" as a field to the cargo query in order to blank edit a result.
* Accidentally removed some tabs from blank lines in the script ^^